### PR TITLE
feat(setZoom): allows the app to set the zoom with broken values

### DIFF
--- a/android/src/main/java/br/com/devmagic/flutter_larix/LarixNativeView.java
+++ b/android/src/main/java/br/com/devmagic/flutter_larix/LarixNativeView.java
@@ -796,9 +796,9 @@ class LarixNativeView implements PlatformView, Streamer.Listener, Application.Ac
 
         mScaleFactor = Math.max(1.0f, Math.min(mScaleFactor, mStreamerGL.getMaxZoom()));
 
-        mStreamerGL.zoomTo(Math.round(mScaleFactor));
+        mStreamerGL.zoomTo(mScaleFactor);
 
-        Float zoomFloat = new Float(Math.round(mScaleFactor));
+        Float zoomFloat = new Float(mScaleFactor);
 
         return zoomFloat.doubleValue(); // consume touch event
     }


### PR DESCRIPTION
Preciso adcionar o zoom 1.2 nas configuracoes do app. 
Na lib todo zoom quebrado (1.x) é arredondado (1) ,logo, retirei o método round.